### PR TITLE
Ignore signal index in rainflow counters

### DIFF
--- a/src/pylife/stress/rainflow/fourpoint.py
+++ b/src/pylife/stress/rainflow/fourpoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 - for information on the respective copyright owner
+# Copyright (c) 2019-2024 - for information on the respective copyright owner
 # see the NOTICE file and/or the repository
 # https://github.com/boschresearch/pylife
 #
@@ -101,6 +101,7 @@ class FourPointDetector(AbstractDetector):
             The ``self`` object so that processing can be chained
         """
 
+        samples = np.asarray(samples)
         residuals = samples[:1] if self._residuals.size == 0 else self._residuals[:-1]
 
         turns_index, turns_values = self._new_turns(samples)

--- a/src/pylife/stress/rainflow/threepoint.py
+++ b/src/pylife/stress/rainflow/threepoint.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 - for information on the respective copyright owner
+# Copyright (c) 2019-2024 - for information on the respective copyright owner
 # see the NOTICE file and/or the repository
 # https://github.com/boschresearch/pylife
 #
@@ -120,6 +120,8 @@ class ThreePointDetector(AbstractDetector):
         self : ThreePointDetector
             The ``self`` object so that processing can be chained
         """
+        samples = np.asarray(samples)
+
         if len(self._residuals) == 0:
             residuals = samples[:1]
             residual_index = [0, 1]

--- a/tests/stress/rainflow/test_fkm.py
+++ b/tests/stress/rainflow/test_fkm.py
@@ -19,6 +19,7 @@ __maintainer__ = __author__
 
 import unittest
 import numpy as np
+import pandas as pd
 
 import pylife.stress.rainflow as RF
 import pylife.stress.rainflow.recorders as RFR
@@ -60,3 +61,8 @@ class TestFKMMemory1_2_3(unittest.TestCase):
 
     def test_residuals(self):
         np.testing.assert_array_equal(self._dtor.residuals, np.array([1., -2.]))
+
+
+def test_series_signal_float_index():
+    signal = pd.Series([0., 1., 0.], index=[1.0, 2.0, 3.0])
+    process_signal(signal)

--- a/tests/stress/rainflow/test_fourpoint.py
+++ b/tests/stress/rainflow/test_fourpoint.py
@@ -20,6 +20,7 @@ __maintainer__ = "Johannes Mueller"
 import unittest
 import pytest
 import numpy as np
+import pandas as pd
 
 import pylife.stress.rainflow as RF
 import pylife.stress.rainflow.recorders as RFR
@@ -474,3 +475,8 @@ def test_split_any_signal_anywhere_twice(signal):
             np.testing.assert_array_equal(fr.index_to, reference_recorder.index_to)
             np.testing.assert_array_equal(dtor.residuals, reference_detector.residuals)
             np.testing.assert_array_equal(dtor.residual_index, reference_detector.residual_index)
+
+
+def test_series_signal_float_index():
+    signal = pd.Series([0., 1., 0.], index=[1.0, 2.0, 3.0])
+    process_signal(signal)

--- a/tests/stress/rainflow/test_threepoint.py
+++ b/tests/stress/rainflow/test_threepoint.py
@@ -20,6 +20,7 @@ __maintainer__ = __author__
 import unittest
 import pytest
 import numpy as np
+import pandas as pd
 
 import pylife.stress.rainflow as RF
 import pylife.stress.rainflow.recorders as RFR
@@ -439,3 +440,8 @@ def test_flipped_signals(signal):
     np.testing.assert_array_equal(flipped_recorder.index_to, np.asarray(reference_recorder.index_to))
     np.testing.assert_array_equal(flipped_detector.residuals, -np.asarray(reference_detector.residuals))
     np.testing.assert_array_equal(flipped_detector.residual_index, np.asarray(reference_detector.residual_index))
+
+
+def test_series_signal_float_index():
+    signal = pd.Series([0., 1., 0.], index=[1.0, 2.0, 3.0])
+    process_signal(signal)


### PR DESCRIPTION
Fixes #69

Reporters can use `.iloc` to restore the original index.