### PR TITLE
Fix bug with scalar call to SeegerBeste.stress

### DIFF
--- a/src/pylife/materiallaws/notch_approximation_law_seegerbeste.py
+++ b/src/pylife/materiallaws/notch_approximation_law_seegerbeste.py
@@ -97,7 +97,7 @@ class SeegerBeste(pylife.materiallaws.notch_approximation_law.NotchApproximation
             # or (value, converged, zero_der) for vector-valued invocation
 
         # only for multiple points at once, if some points diverged
-        if sum(stress[1]) < len(stress[1]):
+        if len(stress) == 3 and sum(stress[1]) < len(stress[1]):
             stress = self._stress_fix_not_converged_values(stress, load, x0, rtol, tol)
 
         return stress[0]
@@ -209,7 +209,7 @@ class SeegerBeste(pylife.materiallaws.notch_approximation_law.NotchApproximation
             # or (value, converged, zero_der) for vector-valued invocation
 
         # only for multiple points at once, if some points diverged
-        if sum(delta_stress[1]) < len(delta_stress[1]):
+        if len(delta_stress) == 3 and sum(delta_stress[1]) < len(delta_stress[1]):
             delta_stress = self._stress_secondary_fix_not_converged_values(delta_stress, delta_load, x0, rtol, tol)
 
         return delta_stress[0]

--- a/tests/materiallaws/test_notch_approximation_law_seegerbeste.py
+++ b/tests/materiallaws/test_notch_approximation_law_seegerbeste.py
@@ -111,6 +111,21 @@ def test_seeger_beste_example_2():
         binned_notch_approximation_law._lut_secondary_branch, expected_matrix_AST_171_seeger_beste, rtol=2e-3, atol=1e-5)
 
 
+def test_seeger_beste_example_no_binning():
+    E = 206e3    # [MPa] Young's modulus
+    K = 1184     # [MPa]
+    n = 0.187    # [-]
+    K_p = 3.5    # [-] (de: Traglastformzahl) K_p = F_plastic / F_yield (3.1.1)
+
+    notch_approximation_law = SeegerBeste(E, K, n, K_p)
+
+    stress = notch_approximation_law.stress(150.0)
+    stress_secondary_branch = notch_approximation_law.stress_secondary_branch(150.0)
+
+    assert np.isclose(stress, 147.1, rtol=1e-3)
+    assert np.isclose(stress_secondary_branch, 149.8, rtol=1e-3)
+
+
 @pytest.mark.skip(reason="Derivatives not implemented at the moment, left in the code because it might be useful in the future for performance optimization with gradient-based root finding algorithms.")
 @pytest.mark.parametrize('stress, load', [
     (4, 9),


### PR DESCRIPTION
See linked issue. This PR solves the bug and adds a test case.