### PR TITLE
Use copy of x0 in scipy.optimize.newton to prevent side effect

### DIFF
--- a/src/pylife/materiallaws/notch_approximation_law.py
+++ b/src/pylife/materiallaws/notch_approximation_law.py
@@ -20,6 +20,7 @@ __maintainer__ = __author__
 import numpy as np
 from scipy import optimize
 import pandas as pd
+import copy
 
 import pylife.materiallaws.rambgood
 
@@ -135,7 +136,7 @@ class ExtendedNeuber(NotchApproximationLawBase):
         '''
         stress = optimize.newton(
             func=self._stress_implicit,
-            x0=load,
+            x0=copy.copy(load),
             fprime=self._d_stress_implicit,
             args=([load]),
             rtol=rtol, tol=tol, maxiter=20
@@ -192,10 +193,9 @@ class ExtendedNeuber(NotchApproximationLawBase):
         # =>   sigma/E + (sigma/K')^(1/n') =  (L/sigma * K_p * e_star)
         # =>   (sigma/E + (sigma/K')^(1/n')) /  K_p * sigma =  L *  e_star(L)
         # <=> self._ramberg_osgood_relation.strain(stress) / self._K_p * stress = L * e_star(L)
-
         load = optimize.newton(
             func=self._load_implicit,
-            x0=stress,
+            x0=copy.copy(stress),
             fprime=self._d_load_implicit,
             args=([stress]),
             rtol=rtol, tol=tol, maxiter=20
@@ -225,7 +225,7 @@ class ExtendedNeuber(NotchApproximationLawBase):
         '''
         delta_stress = optimize.newton(
             func=self._stress_secondary_implicit,
-            x0=delta_load,
+            x0=copy.copy(delta_load),
             fprime=self._d_stress_secondary_implicit,
             args=([delta_load]),
             rtol=rtol, tol=tol, maxiter=20
@@ -281,10 +281,9 @@ class ExtendedNeuber(NotchApproximationLawBase):
         # =>   sigma/E + (sigma/K')^(1/n') =  (L/sigma * K_p * e_star)
         # =>   (sigma/E + (sigma/K')^(1/n')) /  K_p * sigma =  L *  e_star(L)
         # <=> self._ramberg_osgood_relation.strain(stress) / self._K_p * stress = L * e_star(L)
-
         delta_load = optimize.newton(
             func=self._load_secondary_implicit,
-            x0=delta_stress,
+            x0=copy.copy(delta_stress),
             fprime=self._d_load_secondary_implicit,
             args=([delta_stress]),
             rtol=rtol, tol=tol, maxiter=20

--- a/tests/materiallaws/test_notch_approximation_law_seegerbeste.py
+++ b/tests/materiallaws/test_notch_approximation_law_seegerbeste.py
@@ -72,6 +72,8 @@ def test_seeger_beste_example_1():
     pd.testing.assert_frame_equal(
         binned_notch_approximation_law._lut_secondary_branch, expected_matrix_AST_162_seeger_beste, rtol=1e-3, atol=1e-5)
 
+    assert np.isclose(binned_notch_approximation_law._lut_primary_branch.load.max(), maximum_absolute_load)
+
 
 def test_seeger_beste_example_2():
     """ example under 2.7.2, p.78 of FKM nonlinear, "Welle mit V-Kerbe" """


### PR DESCRIPTION
This fixes the linked issue.