### PR TITLE
Fix gradient calculation for non-continuous node ids

### DIFF
--- a/src/pylife/mesh/gradient.py
+++ b/src/pylife/mesh/gradient.py
@@ -65,8 +65,10 @@ class Gradient(Mesh):
         self._node_data = np.zeros((len(groups), 4), order='F')
         self._node_data[:, :3] = groups.first()[['x', 'y', 'z']]
         self._node_data[:, 3] = groups[self.value_key].mean()
+        node_index = groups.first().index
         for node, row in zip(groups.first().index, np.nditer(self._node_data.T, flags=['external_loop'], order='F')):
-            diff = self._node_data[self.neighbors[node]-1, :] - row
+            idx = node_index.get_indexer_for(self.neighbors[node])
+            diff = self._node_data[idx, :] - row
             dx, dy, dz = np.linalg.lstsq(diff[:, :3], diff[:, 3], rcond=None)[0]
             self.lst_sqr_grad_dx[node] = dx
             self.lst_sqr_grad_dy[node] = dy
@@ -399,4 +401,3 @@ class Gradient3D(Mesh):
 
         # remove duplicate indices, keep the first node
         return result[~result.index.duplicated(keep='first')]
-

--- a/tests/mesh/test_gradient.py
+++ b/tests/mesh/test_gradient.py
@@ -50,7 +50,7 @@ def test_grad_constant():
     pd.testing.assert_frame_equal(grad, expected, rtol=1e-12)
 
 
-def test_grad_dx():
+def test_grad_dx_continous():
     fkt = [1, 4, 4, 7, 1, 1, 4, 4, 4, 4, 7, 7, 1, 4, 4, 7]
     df = pd.DataFrame({'node_id': [1, 2, 2, 3, 4, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8, 9],
                        'element_id': [1, 1, 2, 2, 1, 3, 1, 2, 3, 4, 2, 4, 3, 3, 4, 4],
@@ -65,6 +65,48 @@ def test_grad_dx():
         'dfct_dy': np.zeros(9),
         'dfct_dz': np.zeros(9)
     }, index=pd.RangeIndex(1, 10, name='node_id'))
+
+    grad = df.gradient.gradient_of('fct')
+
+    pd.testing.assert_frame_equal(grad, expected, rtol=1e-12)
+
+
+def test_grad_dx_gap_in_elset():
+    fkt = [1, 4, 4, 7, 1, 1, 4, 4, 4, 4, 7, 7, 1, 4, 4, 7]
+    df = pd.DataFrame({'node_id': [1, 2, 2, 3, 4, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8, 9],
+                       'element_id': [1, 1, 2, 2, 1, 3, 1, 2, 3, 14, 2, 14, 3, 3, 14, 14],
+                       'x': [0, 1, 1, 2, 0, 0, 1, 1, 1, 1, 2, 2, 0, 1, 1, 2],
+                       'y': [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
+                       'z': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                       'fct': fkt})
+    df = df.set_index(['node_id', 'element_id'])
+
+    expected = pd.DataFrame({
+        'dfct_dx': np.full(9, 3.0),
+        'dfct_dy': np.zeros(9),
+        'dfct_dz': np.zeros(9)
+    }, index=pd.RangeIndex(1, 10, name='node_id'))
+
+    grad = df.gradient.gradient_of('fct')
+
+    pd.testing.assert_frame_equal(grad, expected, rtol=1e-12)
+
+
+def test_grad_dx_gap_in_node_set():
+    fkt = [1, 4, 4, 7, 1, 1, 4, 4, 4, 4, 7, 7, 1, 4, 4, 7]
+    df = pd.DataFrame({'node_id': [1, 2, 2, 3, 4, 4, 15, 15, 15, 15, 16, 16, 17, 18, 18, 19],
+                       'element_id': [1, 1, 2, 2, 1, 3, 1, 2, 3, 4, 2, 4, 3, 3, 4, 4],
+                       'x': [0, 1, 1, 2, 0, 0, 1, 1, 1, 1, 2, 2, 0, 1, 1, 2],
+                       'y': [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2],
+                       'z': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                       'fct': fkt})
+    df = df.set_index(['node_id', 'element_id'])
+
+    expected = pd.DataFrame({
+        'dfct_dx': np.full(9, 3.0),
+        'dfct_dy': np.zeros(9),
+        'dfct_dz': np.zeros(9)
+    }, index=pd.Index([1, 2, 3, 4, 15, 16, 17, 18, 19], name='node_id'))
 
     grad = df.gradient.gradient_of('fct')
 


### PR DESCRIPTION
Fix #170