### PR TITLE
Handle also IntervalIndex and IntervalArray as histogram bins

### DIFF
--- a/src/pylife/stress/rainflow/recorders.py
+++ b/src/pylife/stress/rainflow/recorders.py
@@ -73,6 +73,19 @@ class LoopValueRecorder(AbstractRecorder):
         yedges : ndarray, shape(ny+1,)
             The bin edges along the second dimension.
         """
+        def is_non_continous(intervals):
+            lefts = intervals.left
+            rights = intervals.right
+            return np.any(lefts[1:] != rights[:-1])
+
+        if isinstance(bins, pd.IntervalIndex) or isinstance(bins, pd.arrays.IntervalArray):
+            if not bins.is_non_overlapping_monotonic or is_non_continous(bins):
+                raise ValueError("Intervals must not overlap and must be continuous and monotonic.")
+            new_bins = np.empty(len(bins) + 1)
+            new_bins[:-1] = bins.left
+            new_bins[-1] = bins.right[-1]
+            bins = new_bins
+
         return np.histogram2d(self._values_from, self._values_to, bins)
 
     def histogram(self, bins=10):

--- a/tests/stress/rainflow/test_recorders.py
+++ b/tests/stress/rainflow/test_recorders.py
@@ -161,6 +161,34 @@ def test_full_rainflow_recorder_empty_histogram_5_bins():
     np.testing.assert_array_equal(histogram, np.zeros((5, 5)))
 
 
+def test_full_rainflow_recorder_empty_histogram_interval_index_success():
+    fr = RFR.FullRecorder()
+    interval_bins = pd.interval_range(start=-10.0, end=10.0, periods=5)
+    histogram, _, _ = fr.histogram_numpy(bins=interval_bins)
+    np.testing.assert_array_equal(histogram, np.zeros((5, 5)))
+
+
+def test_full_rainflow_recorder_empty_histogram_interval_array_success():
+    fr = RFR.FullRecorder()
+    interval_bins = pd.arrays.IntervalArray.from_breaks(np.linspace(-10.0, 10.0, 6))
+    histogram, _, _ = fr.histogram_numpy(bins=interval_bins)
+    np.testing.assert_array_equal(histogram, np.zeros((5, 5)))
+
+
+def test_full_rainflow_recorder_empty_histogram_interval_bins_overlapping():
+    fr = RFR.FullRecorder()
+    interval_bins = pd.IntervalIndex.from_tuples([(0.0, 2.0), (1.0, 3.0), (2.0, 4.0)])
+    with pytest.raises(ValueError, match="Intervals must not overlap and must be continuous and monotonic."):
+        histogram, _, _ = fr.histogram_numpy(bins=interval_bins)
+
+
+def test_full_rainflow_recorder_empty_histogram_interval_bins_non_continous():
+    fr = RFR.FullRecorder()
+    interval_bins = pd.IntervalIndex.from_tuples([(0.0, 1.0), (2.0, 3.0), (4.0, 5.0)])
+    with pytest.raises(ValueError, match="Intervals must not overlap and must be continuous and monotonic."):
+        histogram, _, _ = fr.histogram_numpy(bins=interval_bins)
+
+
 @pytest.mark.parametrize('value_from, value_to, index_from, index_to', [
     (23., 42., 11, 17),
     (46., 84., 22, 34)


### PR DESCRIPTION
Fix #161

Fixing this, even though it is not guaranteed to work according to the docs. The solution has limitations that the interval index must be non overlapping monotonic and continuous.