### PR TITLE
Environment variables for abaqus setup #191

### DIFF
--- a/tools/odbserver/README.md
+++ b/tools/odbserver/README.md
@@ -31,21 +31,43 @@ i.e. is deleted, the server process is stopped automatically.
 
 * Create and activate a plain python-2.7 environment without additional
   packages.  For example by
-```
-conda create -n odbserver python=2.7 pip
-```
+  ```
+  conda create -n odbserver python=2.7 pip
+  ```
 
-Instead of `2.7` you must choose the python version of your abaqus version. You
-can find it out using
+  Instead of `2.7` you must choose the python version of your abaqus version. You
+  can find it out using
 
-```
-abaqus python --version
-```
+  ```
+  abaqus python --version
+  ```
 
 * Run
-```
-pip install pylife-odbserver
-```
+  ```
+  pip install pylife-odbserver
+  ```
+
+* Set environment variables (optional)
+
+  The ``odbclient`` will look for your Abaqus binary in
+  * ``C:/Program Files/SIMULIA/<release_year>/EstProducts/win_b64/code/bin/SMALauncher.exe``
+
+  and for the above Python environment in:
+  * ``<repo_root>/.venv-odbserver``
+  * ``C:/Users/<yourname>/.conda/envs/odbserver``
+  * ``C:/Users/<yourname>/.virtualenvs/odbserver``
+
+  If your paths are different, you must either specify them each time you run the ``odbclient``, or you can set them as environment variables as follows:
+  ```powershell
+  [Environment]::SetEnvironmentVariable("ODBSERVER_ABAQUS_BIN", "<absolute/path/to/your/abq.exe>", "User")
+  [Environment]::SetEnvironmentVariable("ODBSERVER_PYTHON_ENV_PATH", "<absolute/path/to/the/above/python/env>", "User")
+  ```
+
+  You can check the above with:
+  ```powershell
+  [Environment]::GetEnvironmentVariable("ODBSERVER_ABAQUS_BIN", "User")
+  [Environment]::GetEnvironmentVariable("ODBSERVER_PYTHON_ENV_PATH", "User")
+  ```
 
 * See the <a href="../odbclient/">instructions in `pylife-odbclient`</a> on how
   to install the client.


### PR DESCRIPTION
Quick notes (to be discussed):

Tests depend on local setup. I needed to change:
------------------------------------------------
line 52:  @pytest.fixture(params=["2024"], scope="session")

line 59:  def pyenvs(abaqus_version):
              # return os.path.join(Path.home(), ".conda", "envs", f"odbserver-{abaqus_version}")
              return os.path.join(Path.home(), 'Documents', 'GitHub', 'pylife', '.venv-odbserver')


several places:  replace Verbatim path with "pyenvs"



Tests that still don't run:
----------------------------
- test_odbclient_version
- test_version_mismatch[2024]

FAILED tests/test_odbclient.py::test_odbclient_version - AssertionError: assert '2.2.0a8.post...e89.d20251202' == '2.2.0a8.post...1ce.d20251104'

FAILED tests/test_odbclient.py::test_version_mismatch[2024] - FileNotFoundError: Couldn't find the specified ``python_env_path``: C:\Users\wim3si\.conda\envs\odbserver-2024-version-mismatch. Please see https://github.com/boschresearch/pylife/blob/develop/tools/odbserver/README.md



---------------------------------------------
We should deprecate pkg_resources !!!
