### PR TITLE
Fix: preserve cycles column during meanstress transformation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -22,6 +22,8 @@
 
 Emma Feege <emma.feege@outlook.com>
 
+Ricardo Sandi <rickysandis@gmail.com>
+
 Robert Bosch GmbH
        Vivien Le Baube <vivien.lebaube@de.bosch.com>
        Sebastian Bucher <Sebastian.Bucher@de.bosch.com>

--- a/src/pylife/strength/meanstress.py
+++ b/src/pylife/strength/meanstress.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-'''
+"""
 Meanstress routines
 ===================
 
@@ -24,7 +24,7 @@ Mean stress transformation methods
 * FKM Goodman
 * Five Segment Correction
 
-'''
+"""
 
 __author__ = "Johannes Mueller, Lena Rapp"
 __maintainer__ = "Johannes Mueller"
@@ -39,7 +39,7 @@ from pylife import PylifeSignal, Broadcaster
 import pylife.stress.collective as CL
 
 
-@pd.api.extensions.register_series_accessor('haigh_diagram')
+@pd.api.extensions.register_series_accessor("haigh_diagram")
 class HaighDiagram(PylifeSignal):
     """Model for a Haigh diagram in order to perform meanstress transformations.
 
@@ -68,7 +68,7 @@ class HaighDiagram(PylifeSignal):
         sets up a FKM Goodman like Haigh diagram.
         """
         vals = np.array(list(segments_dict.values()))
-        idx = pd.IntervalIndex.from_tuples(list(segments_dict.keys()), name='R')
+        idx = pd.IntervalIndex.from_tuples(list(segments_dict.keys()), name="R")
         return HaighDiagram(pd.Series(vals, index=idx))
 
     @classmethod
@@ -85,24 +85,28 @@ class HaighDiagram(PylifeSignal):
         which is valid between ``R==-inf`` and ``R==0``.  Beyond ``R==0`` the slope
         is ``M2` if ``M2`` is given or ``M/3`` if not.
         """
-        if 'M2' not in haigh_fkm_goodman:
-            haigh_fkm_goodman['M2'] = haigh_fkm_goodman['M'] / 3.0
+        if "M2" not in haigh_fkm_goodman:
+            haigh_fkm_goodman["M2"] = haigh_fkm_goodman["M"] / 3.0
 
         M = haigh_fkm_goodman.M
         M2 = haigh_fkm_goodman.M2
-        interval_index = pd.IntervalIndex.from_tuples([(1.0, np.inf), (-np.inf, 0.0), (0.0, 1.)], name='R')
+        interval_index = pd.IntervalIndex.from_tuples(
+            [(1.0, np.inf), (-np.inf, 0.0), (0.0, 1.0)], name="R"
+        )
 
         if isinstance(haigh_fkm_goodman, pd.Series):
             haigh_index = interval_index
-            dummy_index = pd.Index([0, 1, 2], name='R')
+            dummy_index = pd.Index([0, 1, 2], name="R")
         else:
-            haigh_frame, _ = Broadcaster(haigh_fkm_goodman.index.to_frame()).broadcast(interval_index.to_frame())
+            haigh_frame, _ = Broadcaster(haigh_fkm_goodman.index.to_frame()).broadcast(
+                interval_index.to_frame()
+            )
             haigh_index = haigh_frame.index
-            dummy_index = pd.Index([0, 1, 2] * len(haigh_fkm_goodman), name='R')
+            dummy_index = pd.Index([0, 1, 2] * len(haigh_fkm_goodman), name="R")
 
         haigh = pd.Series(0.0, index=dummy_index)
 
-        R_index = haigh.index.get_level_values('R')
+        R_index = haigh.index.get_level_values("R")
 
         haigh.iloc[R_index.get_indexer_for([1])] = M
         haigh.iloc[R_index.get_indexer_for([2])] = M2
@@ -135,31 +139,38 @@ class HaighDiagram(PylifeSignal):
         if was_series:
             five_segment_haigh_diagram = pd.DataFrame(five_segment_haigh_diagram).T
 
-        index_names = five_segment_haigh_diagram.index.names + ['R']
+        index_names = five_segment_haigh_diagram.index.names + ["R"]
 
         def make_index(h):
             orig_index = [h.name] if not isinstance(h.name, Iterable) else list(h.name)
 
-            return pd.MultiIndex.from_tuples([
-                tuple(orig_index + [pd.Interval(1.0, np.inf)]),
-                tuple(orig_index + [pd.Interval(-np.inf, 0.)]),
-                tuple(orig_index + [pd.Interval(0., h.R12)]),
-                tuple(orig_index + [pd.Interval(h.R12, h.R23)]),
-                tuple(orig_index + [pd.Interval(h.R23, 1.)]),
-            ], names=index_names).to_frame()
+            return pd.MultiIndex.from_tuples(
+                [
+                    tuple(orig_index + [pd.Interval(1.0, np.inf)]),
+                    tuple(orig_index + [pd.Interval(-np.inf, 0.0)]),
+                    tuple(orig_index + [pd.Interval(0.0, h.R12)]),
+                    tuple(orig_index + [pd.Interval(h.R12, h.R23)]),
+                    tuple(orig_index + [pd.Interval(h.R23, 1.0)]),
+                ],
+                names=index_names,
+            ).to_frame()
 
-        haigh_index = pd.concat(list(five_segment_haigh_diagram.apply(make_index, axis=1))).index
+        haigh_index = pd.concat(
+            list(five_segment_haigh_diagram.apply(make_index, axis=1))
+        ).index
 
         haigh = pd.Series(0.0, index=haigh_index)
 
-        R_index = haigh.index.get_level_values('R')
+        R_index = haigh.index.get_level_values("R")
         h, _ = Broadcaster(haigh).broadcast(five_segment_haigh_diagram)
 
         M4_locs = R_index.get_indexer_for([pd.Interval(1.0, np.inf)])
-        M0_locs = R_index.get_indexer_for([pd.Interval(-np.inf, 0.)])
-        M1_locs = R_index.get_indexer_for([pd.Interval(0., R12) for R12 in h.R12])
-        M2_locs = R_index.get_indexer_for([pd.Interval(R12, R23) for R12, R23 in zip(h.R12, h.R23)])
-        M3_locs = R_index.get_indexer_for([pd.Interval(R23, 1.) for R23 in h.R23])
+        M0_locs = R_index.get_indexer_for([pd.Interval(-np.inf, 0.0)])
+        M1_locs = R_index.get_indexer_for([pd.Interval(0.0, R12) for R12 in h.R12])
+        M2_locs = R_index.get_indexer_for(
+            [pd.Interval(R12, R23) for R12, R23 in zip(h.R12, h.R23)]
+        )
+        M3_locs = R_index.get_indexer_for([pd.Interval(R23, 1.0) for R23 in h.R23])
 
         haigh.iloc[M4_locs] = h.M4.iloc[M4_locs]
         haigh.iloc[M0_locs] = h.M0.iloc[M0_locs]
@@ -177,20 +188,32 @@ class HaighDiagram(PylifeSignal):
 
         Parameters
         ----------
-        cycles : :class:`pd.Series` accepted by class:``LoadCollective` or class:`LoadHistogram``
-            The load collective
+        cycles : pd.Series or pd.DataFrame
+            The load cycles or collective to transform.
+            If a DataFrame, it may contain a 'cycles' column which will be
+            copied unchanged to the result.
+        R_goal : float
+            The target R-value for the transformation.
 
         Returns
         -------
-        transformed_cycles : :class:`pd.Series`
-            The transformed cycles
+        pd.DataFrame
+            DataFrame with columns:
+            - 'range': transformed amplitude range
+            - 'mean': transformed mean value
+            - 'cycles': copied unchanged from the input if present
         """
-        cycles, obj = self.broadcast(cycles, droplevel=['R'])
+
+        original_cycles = cycles
+
+        cycles, obj = self.broadcast(cycles, droplevel=["R"])
 
         transformer = _SegmentTransformer(cycles, obj, self._R_index, R_goal)
 
         for interval in transformer.segments_left_from_R_goal():
-            interval_boundary = interval.right if interval.right < 1.0 else interval.left
+            interval_boundary = (
+                interval.right if interval.right < 1.0 else interval.left
+            )
             transformer.transform_cycles_in_interval(interval, interval_boundary)
 
         for interval in transformer.segments_right_from_R_goal():
@@ -200,10 +223,22 @@ class HaighDiagram(PylifeSignal):
             transformer.transform_cycles_in_interval(interval, R_goal)
 
         transfomed_cycles = transformer.transformed_cycles
-        res = pd.DataFrame({
-            'range': 2. * transfomed_cycles.amplitude,
-            'mean': transfomed_cycles.amplitude * ((1.+transfomed_cycles.R)/(1.-transfomed_cycles.R)).fillna(-1.0)
-        }, index=cycles.index)
+        res = pd.DataFrame(
+            {
+                "range": 2.0 * transfomed_cycles.amplitude,
+                "mean": transfomed_cycles.amplitude
+                * ((1.0 + transfomed_cycles.R) / (1.0 - transfomed_cycles.R)).fillna(
+                    -1.0
+                ),
+            },
+            index=cycles.index,
+        )
+
+        if (
+            isinstance(original_cycles, pd.DataFrame)
+            and "cycles" in original_cycles.columns
+        ):
+            res["cycles"] = original_cycles["cycles"]
 
         return res
 
@@ -212,23 +247,32 @@ class HaighDiagram(PylifeSignal):
         def has_gaps(idx):
             if len(idx) <= 1:
                 return False
-            return (pd.DataFrame({'l': idx.left[1:], 'r': idx.right[:-1]})
-                    .apply(lambda r: r.l != r.r and not (r.l == -np.inf and r.r == np.inf), axis=1)
-                    .any())
+            return (
+                pd.DataFrame({"l": idx.left[1:], "r": idx.right[:-1]})
+                .apply(
+                    lambda r: r.l != r.r and not (r.l == -np.inf and r.r == np.inf),
+                    axis=1,
+                )
+                .any()
+            )
 
         self._R_index = self._find_R_index()
 
         if self._check_if_R_index(lambda idx: idx.is_overlapping):
-            raise AttributeError("The intervals of the 'R' IntervalIndex must not overlap.")
+            raise AttributeError(
+                "The intervals of the 'R' IntervalIndex must not overlap."
+            )
 
         if self._check_if_R_index(has_gaps):
-            raise AttributeError("The intervals of the 'R' IntervalIndex must not have gaps.")
+            raise AttributeError(
+                "The intervals of the 'R' IntervalIndex must not have gaps."
+            )
 
     def _find_R_index(self):
-        if 'R' not in self._obj.index.names:
+        if "R" not in self._obj.index.names:
             raise AttributeError("A Haigh Diagram needs an index level 'R'.")
         if isinstance(self._obj.index, pd.MultiIndex):
-            R_index = self._obj.index.unique('R')
+            R_index = self._obj.index.unique("R")
         else:
             R_index = self._obj.index
         if not isinstance(R_index, pd.IntervalIndex):
@@ -239,13 +283,12 @@ class HaighDiagram(PylifeSignal):
         if isinstance(self._obj.index, pd.IntervalIndex):
             return check_func(self._obj.index)
 
-        all_but_R = [n or 0 for n in self._obj.index.names if n != 'R']
+        all_but_R = [n or 0 for n in self._obj.index.names if n != "R"]
 
         return (
-            self
-            ._obj.index.to_frame(index=False)
+            self._obj.index.to_frame(index=False)
             .groupby(all_but_R)
-            .apply(lambda g: check_func(g.set_index('R').index), include_groups=False)
+            .apply(lambda g: check_func(g.set_index("R").index), include_groups=False)
             .any()
         )
 
@@ -254,10 +297,9 @@ class _SegmentTransformer:
 
     def __init__(self, cycles, haigh, R_segments, R_goal):
         rf = cycles.load_collective
-        self.transformed_cycles = pd.DataFrame({
-            'amplitude': rf.amplitude,
-            'R': rf.R
-        }, index=cycles.index)
+        self.transformed_cycles = pd.DataFrame(
+            {"amplitude": rf.amplitude, "R": rf.R}, index=cycles.index
+        )
         self._haigh = haigh
         self._R_index = R_segments
         self._R_goal = R_goal
@@ -265,24 +307,26 @@ class _SegmentTransformer:
         self._distances = self._distance_from_R_goal()
 
     def segments_left_from_R_goal(self):
-        return self._distances[self._distances < 0.].sort_values(ascending=True).index
+        return self._distances[self._distances < 0.0].sort_values(ascending=True).index
 
     def segments_right_from_R_goal(self):
-        return self._distances[self._distances > 0.].sort_values(ascending=False).index
+        return self._distances[self._distances > 0.0].sort_values(ascending=False).index
 
     def segments_containing_R_goal(self):
         goal_segments = self._R_index.contains(self._R_goal)
         if not goal_segments.any():
-            goal_segments = self._R_index.set_closed('left').contains(self._R_goal)
+            goal_segments = self._R_index.set_closed("left").contains(self._R_goal)
 
         return self._R_index[goal_segments]
 
     def _distance_from_R_goal(self):
         def fake_meanstress(R):
-            return (1.+R)/(1.-R)
+            return (1.0 + R) / (1.0 - R)
 
         meanstress = fake_meanstress(self._R_index.mid).fillna(-1.0)
-        meanstress_goal = -1.0 if self._R_goal == -np.inf else fake_meanstress(self._R_goal)
+        meanstress_goal = (
+            -1.0 if self._R_goal == -np.inf else fake_meanstress(self._R_goal)
+        )
 
         return pd.Series(meanstress.values - meanstress_goal, index=self._R_index)
 
@@ -296,7 +340,7 @@ class _SegmentTransformer:
 
         def cycles_in_current_interval():
             R = self.transformed_cycles.R.apply(push_over_flipping_point)
-            test_interval = pd.Interval(interval.left, interval.right, closed='both')
+            test_interval = pd.Interval(interval.left, interval.right, closed="both")
             return R.apply(lambda R: R in test_interval)
 
         def cycles_in_current_segments(in_test_interval, segments_index):
@@ -306,19 +350,23 @@ class _SegmentTransformer:
             return in_test_interval & in_segments_index
 
         def meanstress_sensitivity_segments_of_current_interval():
-            return self._haigh.xs(interval, level='R')
+            return self._haigh.xs(interval, level="R")
 
         def transformed_amplitude():
             rf = self.transformed_cycles.loc[to_shift]
             amp = rf.amplitude
-            mean = amp * (1.+rf.R)/(1.-rf.R)
+            mean = amp * (1.0 + rf.R) / (1.0 - rf.R)
             mean[rf.R == -np.inf] = -amp[rf.R == -np.inf]
             mean[rf.R == 1.0] = -amp[rf.R == 1.0]
 
             if R_goal == -np.inf:
-                trans_amp = (amp + M * mean) / (1. - M)
+                trans_amp = (amp + M * mean) / (1.0 - M)
             else:
-                trans_amp = (1. - R_goal) * (amp + M*mean) / (1. - R_goal + M*(1.+R_goal))
+                trans_amp = (
+                    (1.0 - R_goal)
+                    * (amp + M * mean)
+                    / (1.0 - R_goal + M * (1.0 + R_goal))
+                )
 
             return trans_amp.fillna(0.0)
 
@@ -335,8 +383,8 @@ class _SegmentTransformer:
         if R_goal == 1.0:
             R_goal = -np.inf
 
-        self.transformed_cycles.loc[to_shift, 'amplitude'] = transformed_amplitude()
-        self.transformed_cycles.loc[to_shift, 'R'] = R_goal
+        self.transformed_cycles.loc[to_shift, "amplitude"] = transformed_amplitude()
+        self.transformed_cycles.loc[to_shift, "R"] = R_goal
 
 
 def experimental_mean_stress_sensitivity(sn_curve_R0, sn_curve_Rn1, N_c=np.inf):
@@ -374,15 +422,26 @@ def experimental_mean_stress_sensitivity(sn_curve_R0, sn_curve_Rn1, N_c=np.inf):
         if the resulting M_sigma doesn't lie in the range from 0 to 1 a ValueError is raised, as this value would
         suggest higher strength with additional loads.
     """
-    S_a_R0 = sn_curve_R0.woehler.basquin_load(N_c) if N_c < sn_curve_R0.ND else sn_curve_R0.SD
-    S_a_Rn1 = sn_curve_Rn1.woehler.basquin_load(N_c) if N_c < sn_curve_Rn1.ND else sn_curve_Rn1.SD
+    S_a_R0 = (
+        sn_curve_R0.woehler.basquin_load(N_c)
+        if N_c < sn_curve_R0.ND
+        else sn_curve_R0.SD
+    )
+    S_a_Rn1 = (
+        sn_curve_Rn1.woehler.basquin_load(N_c)
+        if N_c < sn_curve_Rn1.ND
+        else sn_curve_Rn1.SD
+    )
     M_sigma = S_a_Rn1 / S_a_R0 - 1
     if not 0 <= M_sigma <= 1:
-        raise ValueError("M_sigma: %.2f exceeds the interval [0, 1] which is not plausible." % M_sigma)
+        raise ValueError(
+            "M_sigma: %.2f exceeds the interval [0, 1] which is not plausible."
+            % M_sigma
+        )
     return M_sigma
 
 
-@pd.api.extensions.register_dataframe_accessor('meanstress_transform')
+@pd.api.extensions.register_dataframe_accessor("meanstress_transform")
 class MeanstressTransformCollective(CL.LoadCollective):
 
     def fkm_goodman(self, ms_sens, R_goal):
@@ -396,39 +455,43 @@ class MeanstressTransformCollective(CL.LoadCollective):
         return res.load_collective
 
 
-@pd.api.extensions.register_series_accessor('meanstress_transform')
+@pd.api.extensions.register_series_accessor("meanstress_transform")
 class MeanstressTransformMatrix(CL.LoadHistogram):
 
     def _validate(self):
         super()._validate()
 
-        if set(self._obj.index.names).issuperset({'from', 'to'}):
-            f = self._obj.index.get_level_values('from').mid
-            t = self._obj.index.get_level_values('to').mid
-            self._Sa = np.abs(f-t)/2.
-            self._Sm = (f+t)/2.
-            self._binsize_x = self._obj.index.get_level_values('from').length.min()
-            self._binsize_y = self._obj.index.get_level_values('to').length.min()
-            self._remaining_names = list(filter(lambda n: n not in ['from', 'to'], self._obj.index.names))
+        if set(self._obj.index.names).issuperset({"from", "to"}):
+            f = self._obj.index.get_level_values("from").mid
+            t = self._obj.index.get_level_values("to").mid
+            self._Sa = np.abs(f - t) / 2.0
+            self._Sm = (f + t) / 2.0
+            self._binsize_x = self._obj.index.get_level_values("from").length.min()
+            self._binsize_y = self._obj.index.get_level_values("to").length.min()
+            self._remaining_names = list(
+                filter(lambda n: n not in ["from", "to"], self._obj.index.names)
+            )
         else:
-            self._Sa = self._obj.index.get_level_values('range').mid / 2.
-            self._Sm = self._obj.index.get_level_values('mean').mid
-            self._binsize_x = self._obj.index.get_level_values('range').length.min()
-            self._binsize_y = self._obj.index.get_level_values('mean').length.min()
-            self._remaining_names = list(filter(lambda n: n not in ['range', 'mean'], self._obj.index.names))
+            self._Sa = self._obj.index.get_level_values("range").mid / 2.0
+            self._Sm = self._obj.index.get_level_values("mean").mid
+            self._binsize_x = self._obj.index.get_level_values("range").length.min()
+            self._binsize_y = self._obj.index.get_level_values("mean").length.min()
+            self._remaining_names = list(
+                filter(lambda n: n not in ["range", "mean"], self._obj.index.names)
+            )
 
     def fkm_goodman(self, haigh, R_goal):
-        ranges = HaighDiagram.fkm_goodman(haigh).transform(self._obj, R_goal)['range']
+        ranges = HaighDiagram.fkm_goodman(haigh).transform(self._obj, R_goal)["range"]
         return self._rebin_results(ranges, R_goal).load_collective
 
     def _rebin_results(self, ranges, R_goal):
 
         def resulting_intervals():
             ranges_max = ranges.max()
-            binsize = np.hypot(self._binsize_x, self._binsize_y) / np.sqrt(2.)
+            binsize = np.hypot(self._binsize_x, self._binsize_y) / np.sqrt(2.0)
             bincount = int(np.ceil(ranges_max / binsize))
-            range_bins = np.linspace(0, ranges_max, bincount+1)
-            means_bins = range_bins * (1. + R_goal) / (2.0 * (1. - R_goal))
+            range_bins = np.linspace(0, ranges_max, bincount + 1)
+            means_bins = range_bins * (1.0 + R_goal) / (2.0 * (1.0 - R_goal))
             range_itv = pd.IntervalIndex.from_breaks(range_bins, name="range")
             means_itv = pd.IntervalIndex.from_breaks(means_bins, name="mean")
             return range_itv, means_itv
@@ -438,59 +501,60 @@ class MeanstressTransformMatrix(CL.LoadHistogram):
             level_names = list(projection.index)
             ranges = ranges.xs(level_values, level=level_names)
             obj = obj.xs(level_values, level=level_names)
-            sums = (
-                itvs
-                .to_series()
-                .apply(lambda iv: sum_intervals(iv, ranges, obj))
-            )
+            sums = itvs.to_series().apply(lambda iv: sum_intervals(iv, ranges, obj))
             return sums
 
         def sum_intervals(iv, ranges, obj):
             op_left = op.ge if iv.left == 0.0 else op.gt
-            return obj.iloc[op_left(ranges.values, iv.left) & op.le(ranges.values, iv.right)].sum()
+            return obj.iloc[
+                op_left(ranges.values, iv.left) & op.le(ranges.values, iv.right)
+            ].sum()
 
         if ranges.shape[0] == 0:
-            new_idx = pd.IntervalIndex(pd.interval_range(0.,  0., 0), name='range')
-            return pd.Series([], index=new_idx, name='cycles', dtype=np.float64)
+            new_idx = pd.IntervalIndex(pd.interval_range(0.0, 0.0, 0), name="range")
+            return pd.Series([], index=new_idx, name="cycles", dtype=np.float64)
 
         range_itv_idx, means_itg_idx = resulting_intervals()
 
         if len(self._remaining_names) > 0:
-            remaining_idx = self._obj.index.to_frame(index=False).groupby(self._remaining_names).first().index
-            result = (
-                remaining_idx.to_frame(index=False)
-                .apply(lambda p: aggregate_on_projection(p, range_itv_idx, ranges, self._obj), axis=1)
+            remaining_idx = (
+                self._obj.index.to_frame(index=False)
+                .groupby(self._remaining_names)
+                .first()
+                .index
+            )
+            result = remaining_idx.to_frame(index=False).apply(
+                lambda p: aggregate_on_projection(p, range_itv_idx, ranges, self._obj),
+                axis=1,
             )
             result.index = remaining_idx
             result.columns = pd.MultiIndex.from_arrays([result.columns, means_itg_idx])
-            result = result.stack(['range', 'mean'], future_stack=True).reorder_levels(
-                ['range', 'mean'] + self._remaining_names
+            result = result.stack(["range", "mean"], future_stack=True).reorder_levels(
+                ["range", "mean"] + self._remaining_names
             )
         else:
-            result = range_itv_idx.to_series().apply(lambda iv: sum_intervals(iv, ranges, self._obj))
+            result = range_itv_idx.to_series().apply(
+                lambda iv: sum_intervals(iv, ranges, self._obj)
+            )
             result.index = pd.MultiIndex.from_arrays([result.index, means_itg_idx])
 
         return result
 
 
 def fkm_goodman(amplitude, meanstress, M, M2, R_goal):
-    cycles = pd.DataFrame({
-        'range': 2.*amplitude,
-        'mean': meanstress
-    })
+    cycles = pd.DataFrame({"range": 2.0 * amplitude, "mean": meanstress})
 
-    haigh_fkm_goodman = pd.Series({
-        'M': M,
-        'M2': M2
-    })
+    haigh_fkm_goodman = pd.Series({"M": M, "M2": M2})
     hd = HaighDiagram.fkm_goodman(haigh_fkm_goodman)
 
     res = hd.transform(cycles, R_goal)
     return res.load_collective.amplitude.to_numpy()
 
 
-def five_segment_correction(amplitude, meanstress, M0, M1, M2, M3, M4, R12, R23, R_goal):
-    ''' Performs a mean stress transformation to R_goal according to the
+def five_segment_correction(
+    amplitude, meanstress, M0, M1, M2, M3, M4, R12, R23, R_goal
+):
+    """Performs a mean stress transformation to R_goal according to the
         Five Segment Mean Stress Correction
 
     :param Sa: the stress amplitude
@@ -505,22 +569,13 @@ def five_segment_correction(amplitude, meanstress, M0, M1, M2, M3, M4, R12, R23,
     :param R23: R-value between M2 and M3
 
     :returns: the transformed stress range
-    '''
+    """
 
-    cycles = pd.DataFrame({
-        'range': 2.*amplitude,
-        'mean': meanstress
-    })
+    cycles = pd.DataFrame({"range": 2.0 * amplitude, "mean": meanstress})
 
-    haigh_five_segment = pd.Series({
-        'M0': M0,
-        'M1': M1,
-        'M2': M2,
-        'M3': M3,
-        'M4': M4,
-        'R12': R12,
-        'R23': R23
-    })
+    haigh_five_segment = pd.Series(
+        {"M0": M0, "M1": M1, "M2": M2, "M3": M3, "M4": M4, "R12": R12, "R23": R23}
+    )
 
     hd = HaighDiagram.five_segment(haigh_five_segment)
     res = hd.transform(cycles, R_goal)

--- a/tests/strength/test_meanstress_collective.py
+++ b/tests/strength/test_meanstress_collective.py
@@ -24,68 +24,130 @@ import pylife.strength.meanstress as MST
 
 @pytest.fixture
 def ms_sens():
-    return pd.Series({'M': 0.5, 'M2': 0.5/3.})
+    return pd.Series({"M": 0.5, "M2": 0.5 / 3.0})
 
 
 def test_meanstress_collective_empty_fail():
-    df = pd.DataFrame({'foo': [], 'bar': []})
+    df = pd.DataFrame({"foo": [], "bar": []})
     with pytest.raises(AttributeError, match="Load collective"):
         df.meanstress_transform
 
 
 def test_meanstress_collective_empty_fkm_goodman(ms_sens):
-    df = pd.DataFrame(columns=['from', 'to'])
+    df = pd.DataFrame(columns=["from", "to"])
 
-    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.).to_pandas()
-    assert 'from' in res.columns
-    assert 'to' in res.columns
+    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.0).to_pandas()
+    assert "from" in res.columns
+    assert "to" in res.columns
     assert len(res.columns) == 2
     assert res.shape[0] == 0
 
 
 def test_meanstress_collective_fkm_goodman_single_ms_sens(ms_sens):
-    df = pd.DataFrame({
-        'from': [-6., -4.,  -5./2., -1., -0.4, 0., 7./12.],
-        'to': [-2., 0., 0.5, 1., 1.2, 4./3., 21./12.]
-    }, index=[3, 4, 5, 6, 7, 8, 9])
+    df = pd.DataFrame(
+        {
+            "from": [-6.0, -4.0, -5.0 / 2.0, -1.0, -0.4, 0.0, 7.0 / 12.0],
+            "to": [-2.0, 0.0, 0.5, 1.0, 1.2, 4.0 / 3.0, 21.0 / 12.0],
+        },
+        index=[3, 4, 5, 6, 7, 8, 9],
+    )
 
-    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.)
+    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.0)
 
-    expected_amplitude = pd.Series(np.ones(7), name='amplitude', index=df.index)
+    expected_amplitude = pd.Series(np.ones(7), name="amplitude", index=df.index)
     pd.testing.assert_series_equal(res.amplitude, expected_amplitude)
 
-    expected_meanstress = pd.Series(np.zeros(7), name='meanstress', index=df.index)
+    expected_meanstress = pd.Series(np.zeros(7), name="meanstress", index=df.index)
     pd.testing.assert_series_equal(res.meanstress, expected_meanstress)
 
 
 def test_meanstress_collective_fkm_goodman_multiple_ms_sens():
-    df = pd.DataFrame({
-        'from': [-6., -4.,  -5./2., -1., -0.4, 0., 7./12.],
-        'to': [-2., 0., 0.5, 1., 1.2, 4./3., 21./12.]
-    }, index=pd.Index([3, 4, 5, 6, 7, 8, 9], name='element_id'))
+    df = pd.DataFrame(
+        {
+            "from": [-6.0, -4.0, -5.0 / 2.0, -1.0, -0.4, 0.0, 7.0 / 12.0],
+            "to": [-2.0, 0.0, 0.5, 1.0, 1.2, 4.0 / 3.0, 21.0 / 12.0],
+        },
+        index=pd.Index([3, 4, 5, 6, 7, 8, 9], name="element_id"),
+    )
 
-    ms_sens = pd.DataFrame({
-        'M': [0.5, 0.4],
-        'M2': [0.5/3., 0.4/3.]
-    })
+    ms_sens = pd.DataFrame({"M": [0.5, 0.4], "M2": [0.5 / 3.0, 0.4 / 3.0]})
 
-    expected_index = pd.MultiIndex.from_tuples([
-        (0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (0, 8), (0, 9),
-        (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8), (1, 9)
-    ], names=[None, 'element_id'])
+    expected_index = pd.MultiIndex.from_tuples(
+        [
+            (0, 3),
+            (0, 4),
+            (0, 5),
+            (0, 6),
+            (0, 7),
+            (0, 8),
+            (0, 9),
+            (1, 3),
+            (1, 4),
+            (1, 5),
+            (1, 6),
+            (1, 7),
+            (1, 8),
+            (1, 9),
+        ],
+        names=[None, "element_id"],
+    )
 
-    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.)
+    res = df.meanstress_transform.fkm_goodman(ms_sens, -1.0)
 
     expected_amplitude = pd.Series(
-        [1., 1., 1., 1., 1., 1., 1., 1.2, 1.2, 1.1, 1.0, 0.96, 0.93, 0.91],
+        [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.2, 1.2, 1.1, 1.0, 0.96, 0.93, 0.91],
         index=expected_index,
-        name='amplitude'
+        name="amplitude",
     )
     pd.testing.assert_series_equal(res.amplitude, expected_amplitude, rtol=1e-2)
 
     expected_meanstress = pd.Series(
-        np.zeros(14),
-        index=expected_index,
-        name='meanstress'
+        np.zeros(14), index=expected_index, name="meanstress"
     )
     pd.testing.assert_series_equal(res.meanstress, expected_meanstress, rtol=1e-2)
+
+
+def test_meanstress_collective_preserves_cycles():
+    collective = pd.DataFrame(
+        {
+            "from": [300.0, -150.0, -250.0],
+            "to": [-300.0, -150.0, 250.0],
+            "cycles": [1e0, 1e1, 1e2],
+        }
+    )
+
+    haigh = pd.Series({"M": 0.5, "M2": 0.5 / 3.0})
+    R_goal = 0.1
+    result = collective.meanstress_transform.fkm_goodman(haigh, R_goal)
+
+    pd.testing.assert_series_equal(result.cycles, collective.cycles)
+
+
+def test_meanstress_transform_preserves_cycles():
+    collective = pd.DataFrame(
+        {
+            "from": [300.0, -150.0, -250.0],
+            "to": [-300.0, -150.0, 250.0],
+            "cycles": [1.0, 10.0, 100.0],
+        }
+    )
+
+    haigh = pd.Series({"M": 0.5, "M2": 0.5 / 3.0})
+    result = collective.meanstress_transform.fkm_goodman(haigh, 0.1)
+
+    pd.testing.assert_series_equal(result.cycles, collective.cycles)
+
+
+def test_meanstress_transform_does_not_normalize_cycles():
+    collective = pd.DataFrame(
+        {
+            "from": [10, 20],
+            "to": [-10, -20],
+            "cycles": [3.5, 7.25],
+        }
+    )
+
+    haigh = pd.Series({"M": 0.5, "M2": 0.5 / 3.0})
+    result = collective.meanstress_transform.fkm_goodman(haigh, 0.1)
+
+    assert not (result.cycles == 1.0).all()


### PR DESCRIPTION
Fixes #198

## Problem
When applying a meanstress transformation to a load collective or histogram,
the cycles column was unintentionally reset to 1.0.

This caused the original cycle counts to be lost.

## Root cause
transform() reconstructed the result DataFrame without correctly propagating
the existing cycles column.

## Solution
Preserve the original cycles values by copying them unchanged into the
result DataFrame.

The meanstress transformation should only affect range/mean values, not
cycle counts.

## Tests
Added regression tests to ensure:

cycles are preserved for load collectives
cycles are not normalized to 1.0
non-unit cycles are kept unchanged

## Notes
All previous details were correctly addressed 

